### PR TITLE
feat: implement wallets tier info API and caching logic

### DIFF
--- a/src/app/api/tier-info/route.ts
+++ b/src/app/api/tier-info/route.ts
@@ -1,0 +1,56 @@
+import { getWalletsTierInfo } from "@/lib/tier";
+import { isArweaveAddress } from "@/utils/address.utils";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const address = searchParams.get("address") as string;
+  const addresses = searchParams.get("addresses") as string;
+
+  if (!address && !addresses) {
+    return NextResponse.json(
+      {
+        error:
+          "Missing address or addresses parameter. Use ?address=id1 or ?addresses=id1,id2,id3",
+      },
+      { status: 400 }
+    );
+  }
+
+  try {
+    let addressesArray = address
+      ? [address]
+      : addresses
+          .split(",")
+          .map((id) => id.trim())
+          .filter(Boolean);
+
+    addressesArray = addressesArray.filter(isArweaveAddress);
+
+    if (addressesArray.length === 0) {
+      return NextResponse.json(
+        { error: "No valid addresses provided" },
+        { status: 400 }
+      );
+    }
+
+    const walletsInfo = await getWalletsTierInfo(addressesArray);
+    const responseJson = address ? walletsInfo[address] : walletsInfo;
+
+    return NextResponse.json(responseJson);
+  } catch (error: unknown) {
+    // Properly handle errors
+    let errorMessage;
+    try {
+      errorMessage =
+        error instanceof Error ? error.message : JSON.stringify(error);
+    } catch {
+      errorMessage = String(error);
+    }
+
+    return NextResponse.json(
+      { error: `Failed to get tier info: ${errorMessage}` },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/aoconnect.ts
+++ b/src/lib/aoconnect.ts
@@ -4,6 +4,12 @@ import {
   createDataItemSigner as createDataItemSignerNode,
 } from "@permaweb/aoconnect/node";
 
+const CU_URL = process.env.CU_URL || "https://cu.ao-testnet.xyz";
+
 export const aoInstance = connect({ MODE: "legacy" });
+export const aoInstanceWithCustomCu = connect({
+  MODE: "legacy",
+  CU_URL,
+});
 
 export const createDataItemSigner = createDataItemSignerNode;

--- a/src/lib/tier.ts
+++ b/src/lib/tier.ts
@@ -1,0 +1,220 @@
+import { retryWithDelay } from "@/utils/retry.utils";
+import { aoInstance } from "./aoconnect";
+import { redis } from "./redis";
+
+type TierWallet = {
+  balance: string;
+  rank: number | "";
+  tier: number;
+  progress: number;
+  snapshotTimestamp: number;
+  totalHolders: number;
+};
+
+type WalletsTierInfo = Record<string, TierWallet>;
+
+type CachedWalletsTierInfo = {
+  walletsTierInfo: WalletsTierInfo;
+  snapshotTimestamp: number;
+  totalWallets: number;
+};
+
+const TierTypes = {
+  PRIME: 1,
+  EDGE: 2,
+  RESERVE: 3,
+  SELECT: 4,
+  CORE: 5,
+} as const;
+
+const TierNames = {
+  1: "Prime",
+  2: "Edge",
+  3: "Reserve",
+  4: "Select",
+  5: "Core",
+} as const;
+
+const Tiers = [
+  // Prime tier (Top 2%)
+  {
+    name: TierNames[TierTypes.PRIME],
+    thresholdPercent: 2, // Top 2% of wallets
+    progressMin: 98, // Progress range: 98-100%
+    progressMax: 100,
+  },
+  // Edge tier (Top 2.01% to 20%)
+  {
+    name: TierNames[TierTypes.EDGE],
+    thresholdPercent: 20, // Top 20% of wallets
+    progressMin: 80, // Progress range: 80-98%
+    progressMax: 98,
+  },
+  // Reserve tier (Top 20.01% to 50%)
+  {
+    name: TierNames[TierTypes.RESERVE],
+    thresholdPercent: 50, // Top 50% of wallets
+    progressMin: 50, // Progress range: 50-80%
+    progressMax: 80,
+  },
+  // Select tier (Top 50.01% to 80%)
+  {
+    name: TierNames[TierTypes.SELECT],
+    thresholdPercent: 80, // Top 80% of wallets
+    progressMin: 20, // Progress range: 20-50%
+    progressMax: 50,
+  },
+  // Core tier (Below 80.01%)
+  {
+    name: TierNames[TierTypes.CORE],
+    thresholdPercent: 100, // Everyone (bottom 20%)
+    progressMin: 0, // Progress range: 0-20%
+    progressMax: 20,
+  },
+];
+
+function getTierThresholds(totalWallets: number) {
+  const tierThresholds = [];
+
+  if (totalWallets > 0) {
+    for (let i = 0; i < Tiers.length; i++) {
+      const tier = Tiers[i];
+      const tierIndex = i + 1; // Convert to 1-based index for tier comparison
+      const tierThreshold = {
+        maxRank: Math.ceil((tier.thresholdPercent * totalWallets) / 100),
+        minRank:
+          tierIndex == TierTypes.PRIME
+            ? 1
+            : tierIndex > TierTypes.PRIME
+            ? Math.ceil((Tiers[i - 1].thresholdPercent * totalWallets) / 100) +
+              1
+            : 1,
+      };
+      tierThresholds.push(tierThreshold);
+    }
+  }
+
+  return tierThresholds;
+}
+
+/**
+ * Calculate progress percent within tier range
+ * @param walletRank The rank of the wallet
+ * @param totalWallets Total number of wallets
+ * @returns Progress percentage within tier range
+ */
+function calculateTierProgressPercent(
+  walletRank: number,
+  totalWallets: number
+): number {
+  if (walletRank <= 0 || totalWallets <= 0) return 0;
+  return (
+    Math.floor(
+      ((totalWallets - walletRank + 1) / totalWallets) * 100 * Math.pow(10, 6)
+    ) / Math.pow(10, 6)
+  );
+}
+
+function getWalletTier(walletRank: number, totalWallets: number): number {
+  if (walletRank === 0) return TierTypes.CORE;
+
+  const tierThresholds = getTierThresholds(totalWallets);
+
+  for (let i = 0; i < Tiers.length; i++) {
+    if (walletRank <= tierThresholds[i].maxRank) {
+      return i + 1; // Return 1-based tier index
+    }
+  }
+
+  return TierTypes.CORE;
+}
+
+async function getWalletsTierInfoFromAo() {
+  const result = await retryWithDelay(() =>
+    aoInstance.dryrun({
+      process: "LApdfPKb-uxyPPxQGEPFRWqAuDymNXLAcAE_xsLNPoQ",
+      tags: [{ name: "Action", value: "Get-Wallets" }],
+    })
+  );
+
+  const data = result?.Messages[0]?.Data ?? "{}";
+  const { wallets, snapshotTimestamp } = JSON.parse(data) as {
+    wallets: Array<{ address: string; balance: string; savings: number }>;
+    snapshotTimestamp: number;
+  };
+
+  const totalWallets = wallets.length;
+
+  const walletsTierInfo = wallets.reduce(
+    (acc: Record<string, TierWallet>, wallet, index) => {
+      const walletRank = index + 1;
+      const tier = getWalletTier(walletRank, totalWallets);
+      const progress = calculateTierProgressPercent(walletRank, totalWallets);
+
+      const walletData = {
+        balance: wallet.balance,
+        rank: walletRank,
+        tier,
+        progress,
+        snapshotTimestamp,
+        totalHolders: totalWallets,
+      };
+
+      acc[wallet.address] = walletData;
+
+      return acc;
+    },
+    {}
+  );
+
+  return { walletsTierInfo, snapshotTimestamp, totalWallets };
+}
+
+export async function getWalletsTierInfo(addresses: string[]) {
+  const cachedWalletsTierInfo = await redis.get<CachedWalletsTierInfo>(
+    "wallets-tier-info"
+  );
+
+  let walletsTierInfo: WalletsTierInfo = {};
+  let snapshotTimestamp = 0;
+  let totalWallets = 0;
+
+  if (!cachedWalletsTierInfo) {
+    ({ walletsTierInfo, snapshotTimestamp, totalWallets } =
+      await getWalletsTierInfoFromAo());
+
+    const cacheAge = Math.floor(
+      (snapshotTimestamp + 24 * 60 * 60 * 1000 - Date.now()) / 1000
+    ); // 24 hours from snapshot
+
+    await redis.set(
+      "wallets-tier-info",
+      { walletsTierInfo, snapshotTimestamp, totalWallets },
+      { ex: cacheAge }
+    );
+  } else {
+    ({ walletsTierInfo, snapshotTimestamp, totalWallets } =
+      cachedWalletsTierInfo);
+  }
+
+  const result = addresses.reduce(
+    (acc: Record<string, TierWallet>, address) => {
+      if (address in walletsTierInfo) {
+        acc[address] = walletsTierInfo[address];
+      } else {
+        acc[address] = {
+          balance: "0",
+          rank: "",
+          tier: TierTypes.CORE,
+          progress: 0,
+          snapshotTimestamp,
+          totalHolders: totalWallets,
+        };
+      }
+      return acc;
+    },
+    {}
+  );
+
+  return result;
+}

--- a/src/lib/tier.ts
+++ b/src/lib/tier.ts
@@ -132,7 +132,7 @@ function getWalletTier(walletRank: number, totalWallets: number): number {
 async function getWalletsTierInfoFromAo() {
   const result = await retryWithDelay(() =>
     aoInstance.dryrun({
-      process: "LApdfPKb-uxyPPxQGEPFRWqAuDymNXLAcAE_xsLNPoQ",
+      process: "rkAezEIgacJZ_dVuZHOKJR8WKpSDqLGfgPJrs_Es7CA",
       tags: [{ name: "Action", value: "Get-Wallets" }],
     })
   );

--- a/src/lib/tier.ts
+++ b/src/lib/tier.ts
@@ -1,5 +1,5 @@
 import { retryWithDelay } from "@/utils/retry.utils";
-import { aoInstance } from "./aoconnect";
+import { aoInstanceWithCustomCu } from "./aoconnect";
 import { redis } from "./redis";
 
 type TierWallet = {
@@ -131,7 +131,7 @@ function getWalletTier(walletRank: number, totalWallets: number): number {
 
 async function getWalletsTierInfoFromAo() {
   const result = await retryWithDelay(() =>
-    aoInstance.dryrun({
+    aoInstanceWithCustomCu.dryrun({
       process: "rkAezEIgacJZ_dVuZHOKJR8WKpSDqLGfgPJrs_Es7CA",
       tags: [{ name: "Action", value: "Get-Wallets" }],
     })

--- a/src/utils/address.utils.ts
+++ b/src/utils/address.utils.ts
@@ -1,0 +1,2 @@
+export const isArweaveAddress = (addr: string) =>
+  typeof addr === "string" && /^[a-z0-9_-]{43}$/i.test(addr);


### PR DESCRIPTION
## Summary  
This PR introduces the **Tier API** to fetch tier information for wallet addresses.  

## TODO – WIP  
- [ ] Implement an improved caching mechanism to avoid storing all data under a single key.  
  - Store all holder wallet addresses in a dedicated key to track which wallet tier info is cached.  
  - Cache wallet data per address key.  
  - On fetch:  
    - If the address key exists → return cached tier info.  
    - If not present → check against the saved wallet addresses to decide whether to return a default tier or throw an error.  
